### PR TITLE
v1.1.0 - System.MissingMethodException

### DIFF
--- a/SecureWebServerHelper.Test/SecureWebServerHelper.Test.csproj
+++ b/SecureWebServerHelper.Test/SecureWebServerHelper.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/SecureWebServerHelper/SecureConfigurationHelper.cs
+++ b/SecureWebServerHelper/SecureConfigurationHelper.cs
@@ -23,6 +23,7 @@ SOFTWARE.
 ***********************************************************************************************/
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
 using System;
 using Microsoft.Azure.KeyVault;
 using Microsoft.Azure.Services.AppAuthentication;
@@ -60,7 +61,7 @@ namespace CSE.SecureWebServerHelper
                 ConfigureAppConfiguration((context, config) =>
                 {
                     // Warning message that if it is not working on development machine.
-                    if (context.HostingEnvironment.IsDevelopment() && envAzureConnectionString == null && azureConnectionString == null)
+                    if (envAzureConnectionString == null && azureConnectionString == null)
                     {
                         Console.WriteLine("WARNING: In case of unexpected behavior/authentication errors please specify env variable 'AzureConnectionString' with value 'RunAs=App;AppId={AppId};TenantId={TenantId};AppKey={ClientSecret}' or configure managed identity (if development infra is wihtin Azure).");
                     }

--- a/SecureWebServerHelper/SecureWebServerHelper.csproj
+++ b/SecureWebServerHelper/SecureWebServerHelper.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;</TargetFrameworks>
     <RootNamespace>CSE.SecureWebServerHelper</RootNamespace>
     <PackageId>CSE.SecureWebServerHelper</PackageId>
     <Authors>Florian Wagner</Authors>
@@ -13,9 +13,9 @@
     <PackageTags>ASPCore, Kestrel, SSL, AppConfiguration, KeyVault</PackageTags>
     <RepositoryType>GIT</RepositoryType>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>1.0.0</Version>
-    <AssemblyVersion>0.1.0.0</AssemblyVersion>
-    <FileVersion>0.1.0.0</FileVersion>
+    <Version>1.1.0</Version>
+    <AssemblyVersion>0.1.1.0</AssemblyVersion>
+    <FileVersion>0.1.1.0</FileVersion>
     <Description>IWebHostBuilder fluent configuration extensions to integrate KeyVault, Azure App Configuration Service with ease to your ASP.NET Core Kestrel Webserver to save secrets and configuration outside appconfig and to integrate SSL certificates and install private CA certificates for secure, trusted microservice communication</Description>
     <SignAssembly>false</SignAssembly>
     <ApplicationIcon />


### PR DESCRIPTION
- Error with WebHostContext in ASP.NET Core 3.0/3.1 (see below)
- Could not find root cause, removed usage of IHostingEnvironment
- Introduced multi homing
- Version to 1.1.0

Unhandled exception. System.MissingMethodException: Method not found: 'Microsoft.AspNetCore.Hosting.IHostingEnvironment Microsoft.AspNetCore.Hosting.WebHostBuilderContext.get_HostingEnvironment()'.
   at CSE.SecureWebServerHelper.SecureConfigurationHelper.<>c__DisplayClass4_0.<ConfigurationFromKeyVault>b__0(WebHostBuilderContext context, IConfigurationBuilder config)
   at Microsoft.AspNetCore.Hosting.GenericWebHostBuilder.<>c__DisplayClass8_0.<ConfigureAppConfiguration>b__0(HostBuilderContext context, IConfigurationBuilder builder)
   at Microsoft.Extensions.Hosting.HostBuilder.BuildAppConfiguration()
   at Microsoft.Extensions.Hosting.HostBuilder.Build()

